### PR TITLE
⚙️ Chore: clsx 설치

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@mumukji/icons": "workspace:*",
     "@mumukji/tokens": "workspace:*",
+    "clsx": "^2.1.1",
     "tslib": "^2.8.1"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,9 @@ importers:
       '@mumukji/tokens':
         specifier: workspace:*
         version: link:../tokens
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -2377,6 +2380,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -7196,6 +7203,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:


### PR DESCRIPTION
<!-- PR 제목:  -->

## ✅ PR 체크리스트

### 1. 코드

- [x] 변수 / 함수 이름이 이해 가능한지
- [x] 기능 정상 동작 & 콘솔 에러 없음

### 2. UI

- [x] UI 동작 및 레이아웃 확인 (해당 없음)

### 3. 스토리북

- [x] Story 업데이트 여부 확인 (해당 없음)

### 4. 컨벤션

- [x] 팀 컨벤션 준수

## 🔗 이슈 번호

- Closes #89

## ✨ 작업한 내용

`@mumukji/ui` 컴포넌트의 **조건부 className 합성**을 위해 [`clsx`](https://github.com/lukeed/clsx)를 도입했습니다.

ui 패키지는 **CSS Modules(`*.module.scss`)** 기반이라 클래스명이 해시되어 `styles.xxx`로 참조해야 하는데, variant/state에 따라 클래스를 동적으로 조합하거나 소비자가 넘긴 `className`을 머지할 때 문자열 템플릿/삼항이 장황해집니다. `clsx`로 깔끔하게 처리합니다.

```tsx
import clsx from 'clsx';
import styles from './Button.module.scss';

className={clsx(styles.button, styles[variant], isActive && styles.active, className)}
```

### 📦 설치 내역

- `pnpm --filter @mumukji/ui add clsx` 로 설치
- **`dependencies`에 추가** (`clsx@^2.1.1`) — 런타임에 필요하므로 peer/dev 아님
- CSS-agnostic 유틸이라 SCSS / CSS Modules와 충돌 없음, ~200B 경량 · 의존성 없음

### 📝 참고

- variant 매핑이 복잡해지면 추후 `cva`(class-variance-authority) 도입을 별도 검토. 현 단계는 `clsx`로 충분.
- CSS Modules 특성상 raw 문자열이 아닌 `styles` 객체 참조(`styles.xxx`)로 넘겨야 클래스가 매칭됨.
