### PR TITLE
[✨ Feature/ui/97] 토큰 타입 기반 스타일 유틸 추가

### DIFF
--- a/packages/ui/rollup.config.mjs
+++ b/packages/ui/rollup.config.mjs
@@ -22,7 +22,7 @@ export default [
       commonjs(),
       typescript({ tsconfig: './tsconfig.json' }),
       postcss({
-        modules: true,
+        autoModules: true,
         extract: true,
         use: ['sass'],
       }),
@@ -45,7 +45,7 @@ export default [
       commonjs(),
       typescript({ tsconfig: './tsconfig.json' }),
       postcss({
-        modules: true,
+        autoModules: true,
         extract: false,
         inject: false,
         use: ['sass'],
@@ -54,6 +54,7 @@ export default [
   },
   {
     input: 'dist/types/index.d.ts',
+    external: [/\.s?css$/, '@mumukji/tokens/semantic-css'],
     output: [{ file: 'dist/index.d.ts', format: 'esm' }],
     plugins: [dts()],
   },

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,1 +1,13 @@
-export {};
+import '@mumukji/tokens';
+import './styles/index.scss';
+
+export { SPACING_TOKENS } from './types';
+export { getSpacingClassName } from './utils';
+export type {
+  GapProps,
+  MarginProps,
+  PaddingProps,
+  Spacing,
+  SpacingProps,
+} from './types';
+export type { SpacingClassPrefix } from './utils';

--- a/packages/ui/src/styles/index.scss
+++ b/packages/ui/src/styles/index.scss
@@ -1,0 +1,1 @@
+@use './spacing';

--- a/packages/ui/src/styles/spacing.scss
+++ b/packages/ui/src/styles/spacing.scss
@@ -1,0 +1,93 @@
+$spacings: (
+  'null',
+  '2xs',
+  'xs',
+  'sm',
+  'md',
+  'lg',
+  'xl',
+  '2xl',
+  '3xl',
+  '4xl',
+  '5xl',
+  '6xl',
+  '7xl',
+  '8xl',
+  '9xl',
+  '10xl',
+  '11xl'
+);
+
+@each $name in $spacings {
+  .SpacingP-#{$name} {
+    padding: var(--spacing-#{$name});
+  }
+
+  .SpacingPx-#{$name} {
+    padding-right: var(--spacing-#{$name});
+    padding-left: var(--spacing-#{$name});
+  }
+
+  .SpacingPy-#{$name} {
+    padding-top: var(--spacing-#{$name});
+    padding-bottom: var(--spacing-#{$name});
+  }
+
+  .SpacingPt-#{$name} {
+    padding-top: var(--spacing-#{$name});
+  }
+
+  .SpacingPr-#{$name} {
+    padding-right: var(--spacing-#{$name});
+  }
+
+  .SpacingPb-#{$name} {
+    padding-bottom: var(--spacing-#{$name});
+  }
+
+  .SpacingPl-#{$name} {
+    padding-left: var(--spacing-#{$name});
+  }
+
+  .SpacingM-#{$name} {
+    margin: var(--spacing-#{$name});
+  }
+
+  .SpacingMx-#{$name} {
+    margin-right: var(--spacing-#{$name});
+    margin-left: var(--spacing-#{$name});
+  }
+
+  .SpacingMy-#{$name} {
+    margin-top: var(--spacing-#{$name});
+    margin-bottom: var(--spacing-#{$name});
+  }
+
+  .SpacingMt-#{$name} {
+    margin-top: var(--spacing-#{$name});
+  }
+
+  .SpacingMr-#{$name} {
+    margin-right: var(--spacing-#{$name});
+  }
+
+  .SpacingMb-#{$name} {
+    margin-bottom: var(--spacing-#{$name});
+  }
+
+  .SpacingMl-#{$name} {
+    margin-left: var(--spacing-#{$name});
+  }
+
+  .SpacingGap-#{$name} {
+    gap: var(--spacing-#{$name});
+  }
+
+  .SpacingColumnGap-#{$name} {
+    column-gap: var(--spacing-#{$name});
+  }
+
+  .SpacingRowGap-#{$name} {
+    row-gap: var(--spacing-#{$name});
+  }
+}

--- a/packages/ui/src/types/index.ts
+++ b/packages/ui/src/types/index.ts
@@ -1,0 +1,9 @@
+export { SPACING_TOKENS } from './spacing';
+
+export type {
+  GapProps,
+  MarginProps,
+  PaddingProps,
+  Spacing,
+  SpacingProps,
+} from './spacing';

--- a/packages/ui/src/types/scss.d.ts
+++ b/packages/ui/src/types/scss.d.ts
@@ -1,3 +1,5 @@
+declare module '*.scss';
+
 declare module '*.module.scss' {
   const classes: { [key: string]: string };
   export default classes;

--- a/packages/ui/src/types/spacing.ts
+++ b/packages/ui/src/types/spacing.ts
@@ -1,0 +1,49 @@
+export const SPACING_TOKENS = [
+  'null',
+  '2xs',
+  'xs',
+  'sm',
+  'md',
+  'lg',
+  'xl',
+  '2xl',
+  '3xl',
+  '4xl',
+  '5xl',
+  '6xl',
+  '7xl',
+  '8xl',
+  '9xl',
+  '10xl',
+  '11xl',
+] as const;
+
+export type Spacing = (typeof SPACING_TOKENS)[number];
+
+export interface PaddingProps {
+  p?: Spacing;
+  px?: Spacing;
+  py?: Spacing;
+  pt?: Spacing;
+  pr?: Spacing;
+  pb?: Spacing;
+  pl?: Spacing;
+}
+
+export interface MarginProps {
+  m?: Spacing;
+  mx?: Spacing;
+  my?: Spacing;
+  mt?: Spacing;
+  mr?: Spacing;
+  mb?: Spacing;
+  ml?: Spacing;
+}
+
+export interface GapProps {
+  gap?: Spacing;
+  columnGap?: Spacing;
+  rowGap?: Spacing;
+}
+
+export type SpacingProps = PaddingProps & MarginProps & GapProps;

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -1,0 +1,3 @@
+export { getSpacingClassName } from './spacingClassName';
+
+export type { SpacingClassPrefix } from './spacingClassName';

--- a/packages/ui/src/utils/spacingClassName.ts
+++ b/packages/ui/src/utils/spacingClassName.ts
@@ -1,0 +1,31 @@
+import type { Spacing } from '../types';
+
+export type SpacingClassPrefix =
+  | 'SpacingP'
+  | 'SpacingPx'
+  | 'SpacingPy'
+  | 'SpacingPt'
+  | 'SpacingPr'
+  | 'SpacingPb'
+  | 'SpacingPl'
+  | 'SpacingM'
+  | 'SpacingMx'
+  | 'SpacingMy'
+  | 'SpacingMt'
+  | 'SpacingMr'
+  | 'SpacingMb'
+  | 'SpacingMl'
+  | 'SpacingGap'
+  | 'SpacingColumnGap'
+  | 'SpacingRowGap';
+
+export const getSpacingClassName = (
+  prefix: SpacingClassPrefix,
+  spacing?: Spacing,
+) => {
+  if (!spacing) {
+    return undefined;
+  }
+
+  return `${prefix}-${spacing}`;
+};


### PR DESCRIPTION
## ✅ PR 체크리스트

### 1. 코드

- [x] 변수 / 함수 이름이 이해 가능한지
- [x] 기능 정상 동작 & 콘솔 에러 없음

### 2. UI

- [x] UI 동작 및 레이아웃 확인

### 3. 스토리북

- [x] Story 업데이트 여부 확인

### 4. 컨벤션

- [x] 팀 컨벤션 준수

## 🔗 이슈 번호

- close #97

## ✨ 작업한 내용

- spacing 토큰 기반 전역 유틸 클래스를 추가했습니다.
  - `SpacingP-*`, `SpacingPx-*`, `SpacingPy-*`, `SpacingPt-*`, `SpacingPr-*`, `SpacingPb-*`, `SpacingPl-*`
  - `SpacingM-*`, `SpacingMx-*`, `SpacingMy-*`, `SpacingMt-*`, `SpacingMr-*`, `SpacingMb-*`, `SpacingMl-*`
  - `SpacingGap-*`, `SpacingColumnGap-*`, `SpacingRowGap-*`
- `@mumukji/tokens`의 semantic spacing CSS variable을 기준으로 spacing class가 생성되도록 정리했습니다.
- UI 패키지 스타일 엔트리와 Rollup 설정을 정리했습니다.
  - 전역 SCSS가 CSS Modules로 해시되지 않도록 `autoModules` 설정 적용
  - `@mumukji/ui/style.css`로 spacing utility CSS를 소비할 수 있도록 구성
- spacing 관련 타입을 추가했습니다.
  - `Spacing`
  - `PaddingProps`
  - `MarginProps`
  - `GapProps`
  - `SpacingProps`
- spacing className 생성 유틸을 추가했습니다. > 스페이싱 참조하는 컴포넌트에서 spacing 유틸 사용하시면 됩니다.
  - `getSpacingClassName`
  - `SpacingClassPrefix`

## 💁 리뷰 요청 / 코멘트

- 수정사항 있으시면 말씀해주세요

## 💡 참고사항
