### PR TITLE
[✨ Feature/UI/91] Box 컴포넌트 제작

### DIFF
--- a/apps/storybook/stories/ui/Box.stories.tsx
+++ b/apps/storybook/stories/ui/Box.stories.tsx
@@ -1,0 +1,85 @@
+import { Box } from '@mumukji/ui';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const SPACING_OPTIONS = [
+  'null',
+  '2xs',
+  'xs',
+  'sm',
+  'md',
+  'lg',
+  'xl',
+  '2xl',
+] as const;
+
+const spacingControl = {
+  control: 'select',
+  options: SPACING_OPTIONS,
+} as const;
+
+const meta: Meta<typeof Box> = {
+  title: 'UI/Box',
+  component: Box,
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    p: 'md',
+    as: 'div',
+  },
+  argTypes: {
+    as: {
+      control: 'inline-radio',
+      options: ['div', 'span', 'main', 'header', 'footer', 'aside', 'nav'],
+    },
+    p: spacingControl,
+    px: spacingControl,
+    py: spacingControl,
+    pt: spacingControl,
+    pr: spacingControl,
+    pb: spacingControl,
+    pl: spacingControl,
+    m: spacingControl,
+    mx: spacingControl,
+    my: spacingControl,
+    mt: spacingControl,
+    mr: spacingControl,
+    mb: spacingControl,
+    ml: spacingControl,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Box>;
+
+export const Default: Story = {
+  args: {
+    children: '기본 div로 렌더링되는 Box입니다.',
+  },
+};
+
+export const Spacing: Story = {
+  args: {
+    p: 'md',
+    mt: 'lg',
+    children: 'padding, margin props를 함께 적용한 예시입니다.',
+  },
+};
+
+export const AsSpan: Story = {
+  args: {
+    as: 'span',
+    p: 'md',
+    children:
+      'span은 인라인 요소라 수직(top/bottom) padding·margin이 기대대로 적용되지 않을 수 있습니다. 필요하다면 className으로 display를 조정하세요.',
+  },
+};
+
+export const AsHeader: Story = {
+  args: {
+    as: 'header',
+    p: 'lg',
+    children: 'header 태그로 렌더링되는 Box입니다.',
+  },
+};

--- a/packages/ui/src/components/box/Box.tsx
+++ b/packages/ui/src/components/box/Box.tsx
@@ -1,0 +1,77 @@
+import clsx from 'clsx';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import type { MarginProps, PaddingProps } from '../../types';
+import { getSpacingPropsClassNames } from '../../utils';
+
+export type BoxAs =
+  | 'div'
+  | 'span'
+  | 'main'
+  | 'header'
+  | 'footer'
+  | 'aside'
+  | 'nav';
+
+export type BoxProps = PaddingProps &
+  MarginProps &
+  Omit<
+    ComponentPropsWithoutRef<BoxAs>,
+    keyof PaddingProps | keyof MarginProps | 'as' | 'style'
+  > & {
+    as?: BoxAs;
+    className?: string;
+    children?: ReactNode;
+  };
+
+/**
+ * - 패딩·마진을 가지는 가장 기본적인 블록 컨테이너입니다. 기본적으로 `<div>`를 렌더링합니다.
+ * - `display: flex`/`grid` 같은 레이아웃 속성은 갖지 않습니다. 필요하다면 Flex/Grid 컴포넌트를 사용하세요.
+ * - 색상·장식 등 시각 속성은 props로 받지 않으며 `className`(SCSS)으로 처리합니다. `style` prop은 이 원칙을 위해 허용하지 않습니다.
+ * - `as="span"`처럼 인라인 태그를 사용하는 경우, 수직(top/bottom) padding·margin이 브라우저 box model상 기대대로 적용되지 않을 수 있습니다.
+ *   이 경우 `className`으로 `display: inline-block` 등을 함께 지정하세요.
+ * - spacing 값으로 `"null"`을 주면 해당 padding/margin을 명시적으로 0으로 리셋합니다.
+ */
+export const Box = ({
+  as: Component = 'div',
+  className,
+  children,
+  p,
+  px,
+  py,
+  pt,
+  pr,
+  pb,
+  pl,
+  m,
+  mx,
+  my,
+  mt,
+  mr,
+  mb,
+  ml,
+  ...rest
+}: BoxProps) => {
+  const spacingProps = {
+    p,
+    px,
+    py,
+    pt,
+    pr,
+    pb,
+    pl,
+    m,
+    mx,
+    my,
+    mt,
+    mr,
+    mb,
+    ml,
+  };
+  const boxClassName = clsx(getSpacingPropsClassNames(spacingProps), className);
+
+  return (
+    <Component className={boxClassName} {...rest}>
+      {children}
+    </Component>
+  );
+};

--- a/packages/ui/src/components/box/Box.tsx
+++ b/packages/ui/src/components/box/Box.tsx
@@ -16,7 +16,7 @@ export type BoxProps = PaddingProps &
   MarginProps &
   Omit<
     ComponentPropsWithoutRef<BoxAs>,
-    keyof PaddingProps | keyof MarginProps | 'as' | 'style'
+    keyof PaddingProps | keyof MarginProps | 'as'
   > & {
     as?: BoxAs;
     className?: string;
@@ -26,7 +26,8 @@ export type BoxProps = PaddingProps &
 /**
  * - 패딩·마진을 가지는 가장 기본적인 블록 컨테이너입니다. 기본적으로 `<div>`를 렌더링합니다.
  * - `display: flex`/`grid` 같은 레이아웃 속성은 갖지 않습니다. 필요하다면 Flex/Grid 컴포넌트를 사용하세요.
- * - 색상·장식 등 시각 속성은 props로 받지 않으며 `className`(SCSS)으로 처리합니다. `style` prop은 이 원칙을 위해 허용하지 않습니다.
+ * - 색상·장식 등 시각 속성은 기본적으로 `className`(SCSS)으로 처리합니다. `style`은 런타임에만 정해지는 값(가상화·드래그 라이브러리 연동 등)을 위해 열어두었지만,
+ *   고정된 값은 가급적 className(SCSS)으로 처리해 주세요. 반응형 미디어쿼리는 특이도상 `style`이 항상 이기므로 `style`로 반응형 값을 주지 마세요.
  * - `as="span"`처럼 인라인 태그를 사용하는 경우, 수직(top/bottom) padding·margin이 브라우저 box model상 기대대로 적용되지 않을 수 있습니다.
  *   이 경우 `className`으로 `display: inline-block` 등을 함께 지정하세요.
  * - spacing 값으로 `"null"`을 주면 해당 padding/margin을 명시적으로 0으로 리셋합니다.

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,6 +4,8 @@ import '@mumukji/tokens/typography-css';
 import '@mumukji/tokens/font-cdn';
 import './styles/index.scss';
 
+export { Box } from './components/box/Box';
+export type { BoxAs, BoxProps } from './components/box/Box';
 export { Section } from './components/section/Section';
 export type { SectionAs, SectionProps } from './components/section/Section';
 


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈 제목과 동일하게 작성해 주세요. -->
<!-- ex) [타입/패키지명/이슈 번호] 이슈 제목 -->
<!-- ex) [✨ Feature/icon/1] 로그인 페이지 UI 구현 -->

## ✅ PR 체크리스트

### 1. 코드

- [x] 변수 / 함수 이름이 이해 가능한지
- [x] 기능 정상 동작 & 콘솔 에러 없음

### 2. UI

- [x] UI 동작 및 레이아웃 확인

### 3. 스토리북

- [x] Story 업데이트 여부 확인

### 4. 컨벤션

- [x] 팀 컨벤션 준수

## 🔗 이슈 번호

<!-- PR과 연관된 이슈 번호를 작성해 주세요. ex) #1 -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->

- close #91

## ✨ 작업한 내용

<!-- 작업한 내용을 작성해 주세요 .-->
<!-- 프리뷰 링크로 확인 어려운 컴포넌트라면 스크린샷을 추가해주세요.-->

- Primitive 계층 Box 컴포넌트 구현 (`packages/ui/src/components/box/Box.tsx`)
- 기본 태그 `div`, `as`로 `div/span/main/header/footer/aside/nav` 중 선택 가능
- 패딩·마진은 props(`p/pt/pb/px/py`, `m/mt/mb/mx/my`)로 제어, 기존 `getSpacingPropsClassNames` 유틸 재사용
- 배경색·보더 등 시각 속성은 props로 받지 않고 `className`(SCSS)으로만 처리, `style` prop은 타입 레벨에서 차단
- `gap`은 Box에 포함하지 않음 (Flex/Grid에서 자체 prop으로 추가 예정)
- `index.ts`에 `Box`/`BoxAs`/`BoxProps` export 추가
- `apps/storybook/stories/ui/Box.stories.tsx` 추가 (Section.stories.tsx와 동일한 톤)

## 💁 리뷰 요청 / 코멘트

<!-- 코드리뷰가 필요한 부분이 있다면 작성해 주세요. -->

- Section과 다르게 `style` prop을 명시적으로 `Omit` 처리했습니다. (시각 속성은 className으로만 받는다는 원칙 강제)
- `as="span"` 사용 시 인라인 요소 특성상 수직 padding/margin이 기대대로 동작하지 않을 수 있어 JSDoc으로 안내했습니다.

## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->

- Flex, Grid는 Box 완료 후 별도 이슈로 진행 예정입니다.