### PR TITLE
[♻️ Refactor/UI/118] 레이아웃 primitive에 forwardRef 지원 추가

### DIFF
--- a/packages/ui/src/components/box/Box.tsx
+++ b/packages/ui/src/components/box/Box.tsx
@@ -1,5 +1,10 @@
 import clsx from 'clsx';
-import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+  type Ref,
+} from 'react';
 import type { SpacingProps } from '../../types';
 import { getSpacingPropsClassNames } from '../../utils';
 
@@ -28,47 +33,58 @@ export type BoxProps = SpacingProps &
  *   이 경우 `className`으로 `display: inline-block` 등을 함께 지정하세요.
  * - spacing 값으로 `"null"`을 주면 해당 padding/margin을 명시적으로 0으로 리셋합니다.
  */
-export const Box = ({
-  as: Component = 'div',
-  className,
-  children,
-  p,
-  px,
-  py,
-  pt,
-  pr,
-  pb,
-  pl,
-  m,
-  mx,
-  my,
-  mt,
-  mr,
-  mb,
-  ml,
-  ...rest
-}: BoxProps) => {
-  const spacingProps = {
-    p,
-    px,
-    py,
-    pt,
-    pr,
-    pb,
-    pl,
-    m,
-    mx,
-    my,
-    mt,
-    mr,
-    mb,
-    ml,
-  };
-  const boxClassName = clsx(getSpacingPropsClassNames(spacingProps), className);
+export const Box = forwardRef<HTMLElement, BoxProps>(
+  (
+    {
+      as: Component = 'div',
+      className,
+      children,
+      p,
+      px,
+      py,
+      pt,
+      pr,
+      pb,
+      pl,
+      m,
+      mx,
+      my,
+      mt,
+      mr,
+      mb,
+      ml,
+      ...rest
+    },
+    ref,
+  ) => {
+    const spacingProps = {
+      p,
+      px,
+      py,
+      pt,
+      pr,
+      pb,
+      pl,
+      m,
+      mx,
+      my,
+      mt,
+      mr,
+      mb,
+      ml,
+    };
+    const boxClassName = clsx(
+      getSpacingPropsClassNames(spacingProps),
+      className,
+    );
+    const boxRef = ref as Ref<HTMLDivElement & HTMLSpanElement>;
 
-  return (
-    <Component className={boxClassName} {...rest}>
-      {children}
-    </Component>
-  );
-};
+    return (
+      <Component ref={boxRef} className={boxClassName} {...rest}>
+        {children}
+      </Component>
+    );
+  },
+);
+
+Box.displayName = 'Box';

--- a/packages/ui/src/components/box/Box.tsx
+++ b/packages/ui/src/components/box/Box.tsx
@@ -77,10 +77,9 @@ export const Box = forwardRef<HTMLElement, BoxProps>(
       getSpacingPropsClassNames(spacingProps),
       className,
     );
-    const boxRef = ref as Ref<HTMLDivElement & HTMLSpanElement>;
 
     return (
-      <Component ref={boxRef} className={boxClassName} {...rest}>
+      <Component ref={ref as Ref<never>} className={boxClassName} {...rest}>
         {children}
       </Component>
     );

--- a/packages/ui/src/components/flex/Flex.tsx
+++ b/packages/ui/src/components/flex/Flex.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { forwardRef } from 'react';
 import type { GapProps } from '../../types';
 import { getGapPropsClassNames } from '../../utils';
 import { Box, type BoxProps } from '../box/Box';
@@ -40,32 +41,39 @@ const getFlexWrapValue = (wrap?: FlexWrap) => {
  * - justify/align/wrap으로 정렬·배치를, gap/columnGap/rowGap으로 자식 간 간격을 제어합니다.
  * - 색상·크기 등 시각 속성은 제공하지 않습니다. 필요하다면 className(SCSS)으로 처리하세요.
  */
-export const Flex = ({
-  as,
-  className,
-  children,
-  justify,
-  align,
-  wrap,
-  gap,
-  columnGap,
-  rowGap,
-  ...rest
-}: FlexProps) => {
-  const wrapValue = getFlexWrapValue(wrap);
+export const Flex = forwardRef<HTMLElement, FlexProps>(
+  (
+    {
+      as,
+      className,
+      children,
+      justify,
+      align,
+      wrap,
+      gap,
+      columnGap,
+      rowGap,
+      ...rest
+    },
+    ref,
+  ) => {
+    const wrapValue = getFlexWrapValue(wrap);
 
-  const flexClassName = clsx(
-    'Flex',
-    justify && `FlexJustify-${justify}`,
-    align && `FlexAlign-${align}`,
-    wrapValue && `FlexWrap-${wrapValue}`,
-    getGapPropsClassNames({ gap, columnGap, rowGap }),
-    className,
-  );
+    const flexClassName = clsx(
+      'Flex',
+      justify && `FlexJustify-${justify}`,
+      align && `FlexAlign-${align}`,
+      wrapValue && `FlexWrap-${wrapValue}`,
+      getGapPropsClassNames({ gap, columnGap, rowGap }),
+      className,
+    );
 
-  return (
-    <Box as={as} className={flexClassName} {...rest}>
-      {children}
-    </Box>
-  );
-};
+    return (
+      <Box ref={ref} as={as} className={flexClassName} {...rest}>
+        {children}
+      </Box>
+    );
+  },
+);
+
+Flex.displayName = 'Flex';

--- a/packages/ui/src/components/grid/Grid.tsx
+++ b/packages/ui/src/components/grid/Grid.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import type { CSSProperties } from 'react';
+import { forwardRef, type CSSProperties } from 'react';
 import type { GapProps } from '../../types';
 import { getGapPropsClassNames } from '../../utils';
 import { Box, type BoxProps } from '../box/Box';
@@ -16,33 +16,45 @@ export type GridProps = BoxProps &
  * - columns/rows로 그리드의 열·행 개수를, gap/columnGap/rowGap으로 자식 간 간격을 제어합니다.
  * - grid-template-areas, 셀 위치 지정, justify/align 등 세부 배치는 prop으로 제공하지 않습니다. 필요하다면 className(SCSS)으로 처리하세요.
  */
-export const Grid = ({
-  as,
-  className,
-  children,
-  columns,
-  rows,
-  gap,
-  columnGap,
-  rowGap,
-  style,
-  ...rest
-}: GridProps) => {
-  const gridClassName = clsx(
-    'Grid',
-    getGapPropsClassNames({ gap, columnGap, rowGap }),
-    className,
-  );
+export const Grid = forwardRef<HTMLElement, GridProps>(
+  (
+    {
+      as,
+      className,
+      children,
+      columns,
+      rows,
+      gap,
+      columnGap,
+      rowGap,
+      style,
+      ...rest
+    },
+    ref,
+  ) => {
+    const gridClassName = clsx(
+      'Grid',
+      getGapPropsClassNames({ gap, columnGap, rowGap }),
+      className,
+    );
 
-  const gridStyle = {
-    ...style,
-    '--grid-columns': columns,
-    '--grid-rows': rows,
-  } as CSSProperties;
+    const gridStyle = {
+      ...style,
+      '--grid-columns': columns,
+      '--grid-rows': rows,
+    } as CSSProperties;
 
-  return (
-    <Box as={as} className={gridClassName} style={gridStyle} {...rest}>
-      {children}
-    </Box>
-  );
-};
+    return (
+      <Box
+        ref={ref}
+        as={as}
+        className={gridClassName}
+        style={gridStyle}
+        {...rest}>
+        {children}
+      </Box>
+    );
+  },
+);
+
+Grid.displayName = 'Grid';

--- a/packages/ui/src/components/list/List.tsx
+++ b/packages/ui/src/components/list/List.tsx
@@ -1,5 +1,10 @@
 import clsx from 'clsx';
-import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+  type Ref,
+} from 'react';
 import type { SpacingProps } from '../../types';
 import { getSpacingPropsClassNames } from '../../utils';
 
@@ -33,28 +38,12 @@ export type ListItemProps = SpacingProps &
  * - `as="ol"`로 순서 있는 목록을 렌더링할 수 있습니다.
  * - 그 외 스타일(list-style 등)은 `className`(SCSS)으로 처리해야 합니다.
  */
-export const List = ({
-  as: Component = 'ul',
-  className,
-  children,
-  p,
-  px,
-  py,
-  pt,
-  pr,
-  pb,
-  pl,
-  m,
-  mx,
-  my,
-  mt,
-  mr,
-  mb,
-  ml,
-  ...rest
-}: ListProps) => {
-  const listClassName = clsx(
-    getSpacingPropsClassNames({
+export const List = forwardRef<HTMLElement, ListProps>(
+  (
+    {
+      as: Component = 'ul',
+      className,
+      children,
       p,
       px,
       py,
@@ -69,42 +58,51 @@ export const List = ({
       mr,
       mb,
       ml,
-    }),
-    className,
-  );
+      ...rest
+    },
+    ref,
+  ) => {
+    const listClassName = clsx(
+      getSpacingPropsClassNames({
+        p,
+        px,
+        py,
+        pt,
+        pr,
+        pb,
+        pl,
+        m,
+        mx,
+        my,
+        mt,
+        mr,
+        mb,
+        ml,
+      }),
+      className,
+    );
 
-  return (
-    <Component className={listClassName} {...rest}>
-      {children}
-    </Component>
-  );
-};
+    const listRef = ref as Ref<HTMLUListElement & HTMLOListElement>;
+
+    return (
+      <Component ref={listRef} className={listClassName} {...rest}>
+        {children}
+      </Component>
+    );
+  },
+);
+
+List.displayName = 'List';
 
 /**
  * - `li`를 추상화한 ListItem 컴포넌트입니다.
  * - 반드시 `List` 컴포넌트 안에서 사용해야 합니다.
  */
-export const ListItem = ({
-  className,
-  children,
-  p,
-  px,
-  py,
-  pt,
-  pr,
-  pb,
-  pl,
-  m,
-  mx,
-  my,
-  mt,
-  mr,
-  mb,
-  ml,
-  ...rest
-}: ListItemProps) => {
-  const listItemClassName = clsx(
-    getSpacingPropsClassNames({
+export const ListItem = forwardRef<HTMLLIElement, ListItemProps>(
+  (
+    {
+      className,
+      children,
       p,
       px,
       py,
@@ -119,13 +117,36 @@ export const ListItem = ({
       mr,
       mb,
       ml,
-    }),
-    className,
-  );
+      ...rest
+    },
+    ref,
+  ) => {
+    const listItemClassName = clsx(
+      getSpacingPropsClassNames({
+        p,
+        px,
+        py,
+        pt,
+        pr,
+        pb,
+        pl,
+        m,
+        mx,
+        my,
+        mt,
+        mr,
+        mb,
+        ml,
+      }),
+      className,
+    );
 
-  return (
-    <li className={listItemClassName} {...rest}>
-      {children}
-    </li>
-  );
-};
+    return (
+      <li ref={ref} className={listItemClassName} {...rest}>
+        {children}
+      </li>
+    );
+  },
+);
+
+ListItem.displayName = 'ListItem';

--- a/packages/ui/src/components/list/List.tsx
+++ b/packages/ui/src/components/list/List.tsx
@@ -82,10 +82,8 @@ export const List = forwardRef<HTMLElement, ListProps>(
       className,
     );
 
-    const listRef = ref as Ref<HTMLUListElement & HTMLOListElement>;
-
     return (
-      <Component ref={listRef} className={listClassName} {...rest}>
+      <Component ref={ref as Ref<never>} className={listClassName} {...rest}>
         {children}
       </Component>
     );

--- a/packages/ui/src/components/section/Section.tsx
+++ b/packages/ui/src/components/section/Section.tsx
@@ -1,5 +1,9 @@
 import clsx from 'clsx';
-import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from 'react';
 import type { SpacingProps } from '../../types';
 import { getSpacingPropsClassNames } from '../../utils';
 
@@ -20,28 +24,12 @@ export type SectionProps = SpacingProps &
  * 제목을 숨겨야 하는 경우 `aria-label` 또는 `aria-labelledby`로 접근 가능한 이름을
  * 제공해야 합니다.
  */
-export const Section = ({
-  as: Component = 'section',
-  className,
-  children,
-  p,
-  px,
-  py,
-  pt,
-  pr,
-  pb,
-  pl,
-  m,
-  mx,
-  my,
-  mt,
-  mr,
-  mb,
-  ml,
-  ...rest
-}: SectionProps) => {
-  const sectionClassName = clsx(
-    getSpacingPropsClassNames({
+export const Section = forwardRef<HTMLElement, SectionProps>(
+  (
+    {
+      as: Component = 'section',
+      className,
+      children,
       p,
       px,
       py,
@@ -56,13 +44,36 @@ export const Section = ({
       mr,
       mb,
       ml,
-    }),
-    className,
-  );
+      ...rest
+    },
+    ref,
+  ) => {
+    const sectionClassName = clsx(
+      getSpacingPropsClassNames({
+        p,
+        px,
+        py,
+        pt,
+        pr,
+        pb,
+        pl,
+        m,
+        mx,
+        my,
+        mt,
+        mr,
+        mb,
+        ml,
+      }),
+      className,
+    );
 
-  return (
-    <Component className={sectionClassName} {...rest}>
-      {children}
-    </Component>
-  );
-};
+    return (
+      <Component ref={ref} className={sectionClassName} {...rest}>
+        {children}
+      </Component>
+    );
+  },
+);
+
+Section.displayName = 'Section';


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈 제목과 동일하게 작성해 주세요. -->
<!-- ex) [타입/패키지명/이슈 번호] 이슈 제목 -->
<!-- ex) [✨ Feature/icon/1] 로그인 페이지 UI 구현 -->

## ✅ PR 체크리스트

### 1. 코드

- [X] 변수 / 함수 이름이 이해 가능한지
- [x] 기능 정상 동작 & 콘솔 에러 없음

### 2. UI

- [x] UI 동작 및 레이아웃 확인

### 3. 스토리북

- [X] Story 업데이트 여부 확인

### 4. 컨벤션

- [X] 팀 컨벤션 준수

## 🔗 이슈 번호

<!-- PR과 연관된 이슈 번호를 작성해 주세요. ex) #1 -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->

- close #118

## ✨ 작업한 내용

<!-- 작업한 내용을 작성해 주세요 .-->
<!-- 프리뷰 링크로 확인 어려운 컴포넌트라면 스크린샷을 추가해주세요.-->

- 기존 완성됐던 프리미티브 컴포넌트들이 forwardRef로 감싸져있지 않아 리액트 18환경에서 ref를 전달할 수 없는 문제가 있었습니다.
- forwardRef로 감싸서 Ref를 전달할 수 있도록 수정했습니다.

## 💁 리뷰 요청 / 코멘트

<!-- 코드리뷰가 필요한 부분이 있다면 작성해 주세요. -->

- 수정사항 있으시면 말씀해주세요.

## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->
